### PR TITLE
Add Docker Windows Engine post

### DIFF
--- a/_posts/2025-03-04-install-docker-windows-engine.md
+++ b/_posts/2025-03-04-install-docker-windows-engine.md
@@ -1,0 +1,61 @@
+---
+title: Install Docker Windows Engine without Docker Desktop
+date: 2025-03-04
+categories: [Docker, Windows]
+tags: [docker, windows, installation]
+comments: true
+---
+
+# Install Docker Windows Engine without Docker Desktop
+
+This guide will help you install Docker Windows Engine without using Docker Desktop, which will avoid the need for the Docker Desktop License. Follow these steps:
+
+1. **Download the Latest Version**
+   - Visit [Docker Windows Engine](https://download.docker.com/win/static/stable/x86_64/) to download the latest version.
+
+2. **Extract the Zip File**
+   - Extract the downloaded zip file to `C:/Docker`.
+
+3. **Update System Environment Path**
+   - Add the `C:/Docker` directory to the System Environment Path to allow easy access to Docker commands from any terminal.
+
+4. **Register Docker as a Service**
+   - Navigate to `C:/Docker` and run the following command in admin mode to register Docker as a service:
+     ```sh
+     dockerd --register-service
+     ```
+
+5. **Start the Docker Service**
+   - Use the following commands to start the Docker service:
+     ```sh
+     Get-Service docker
+     Start-Service docker
+     ```
+
+6. **Verify Installation**
+   - Run the following commands to ensure Docker is installed correctly:
+     ```sh
+     docker --version
+     docker info
+     docker run hello-world
+     ```
+
+7. **Troubleshoot Network Issues**
+   - If you encounter network issues, follow these steps:
+     - Set the environment variable `DOCKER_HOST` to `tcp://127.0.0.1:2375`.
+     - Update or add the configuration in `C:\ProgramData\docker\config\daemon.json` by running the following command:
+       ```sh
+       notepad C:\ProgramData\docker\config\daemon.json
+       ```
+
+     - Add the following content to the `daemon.json` file:
+       ```json
+       {
+         "hosts": ["tcp://0.0.0.0:2375", "npipe://"]
+       }
+       ```
+     - Restart the service:
+       ```sh
+       Stop-Service docker
+       Start-Service docker
+       ```


### PR DESCRIPTION
Add a new blog post on installing Docker Windows Engine without Docker Desktop.

* Create a new file `_posts/2025-03-04-install-docker-windows-engine.md`.
* Add the provided content about installing Docker Windows Engine without Docker Desktop.
* Include relevant headers and tags similar to existing posts.
* Ensure the file follows the existing structure and naming conventions in the `_posts` folder.
* Check the grammar and follow the file format as existing ones.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sudhinsr/sudhinsureshcom/pull/1?shareId=d36476fa-76fc-4645-a39e-dbe700e2b9cf).